### PR TITLE
use RecordNotFound Exception instead of RoutingError

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,9 +1,5 @@
 class ProfilesController < ApplicationController
   def show
-    @user = User.where(:name => request.subdomain).first || not_found
-  end
-  
-  def not_found
-    raise ActionController::RoutingError.new('User Not Found')
+    @user = User.where(:name => request.subdomain).first!
   end
 end


### PR DESCRIPTION
Model.first! raises ActiveRecord::RecordNotFound if no matching record is found.

In production mode, Rails automatically rescues the ActiveRecord::RecordNotFound exception by rendering the 404 error page.
